### PR TITLE
Fix a null safety error in the [SecureGate]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.7.2
+
+* Fix a null safety error in the [SecureGate]
+
 ## 3.7.1
 
 * [WINDOWS] No also lock when user go to windows lock screen/switch user

--- a/lib/secure_gate.dart
+++ b/lib/secure_gate.dart
@@ -98,8 +98,8 @@ class _SecureGateState extends State<SecureGate>
   @override
   Widget build(BuildContext context) {
     return Stack(
-      children: <Widget?>[
-        widget.child,
+      children: <Widget>[
+        widget.child!,
         if (_gateVisibility.value != 0)
           Positioned.fill(
             child: BackdropFilter(
@@ -115,7 +115,7 @@ class _SecureGateState extends State<SecureGate>
           ),
         if (_lock && widget.lockedBuilder != null)
           widget.lockedBuilder!(context, _secureApplicationController),
-      ] as List<Widget>,
+      ],
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: secure_application
 description: Secure app content visibility when user leave app. It will hide content
   in the app switcher and display a frost barrier above locked content when the user get backs
-version: 3.7.1
+version: 3.7.2
 homepage: https://github.com/neckaros/secure_application
 
 environment:


### PR DESCRIPTION
error: type List<Widget?> is not a subtype of type List<Widget> in type cast.

```
<Widget?>[
  widget.child,
  if (_gateVisibility.value != 0)
    Positioned.fill(
      child: BackdropFilter(
        filter: ImageFilter.blur(
            sigmaX: widget.blurr * _gateVisibility.value,
            sigmaY: widget.blurr * _gateVisibility.value),
        child: Container(
          decoration: BoxDecoration(
              color: Colors.grey.shade200
                  .withOpacity(widget.opacity * _gateVisibility.value)),
        ),
      ),
    ),
  if (_lock && widget.lockedBuilder != null)
    widget.lockedBuilder!(context, _secureApplicationController),
] as List<Widget>,
```