### PR TITLE
Allow iOS to show launch image in app switcher

### DIFF
--- a/android/src/main/kotlin/org/jezequel/secure_application/SecureApplicationPlugin.kt
+++ b/android/src/main/kotlin/org/jezequel/secure_application/SecureApplicationPlugin.kt
@@ -85,6 +85,9 @@ public class SecureApplicationPlugin: FlutterPlugin, MethodCallHandler, Activity
     } else if (call.method == "open") {
       activity?.window?.clearFlags(LayoutParams.FLAG_SECURE)
         result.success(true)
+    } else if (call.method == "useLaunchImage") {
+      // This is currently not possible on Android, as far as I am aware
+      result.success(true)
     } else {
       result.success(true)
     }

--- a/ios/Classes/SwiftSecureApplicationPlugin.swift
+++ b/ios/Classes/SwiftSecureApplicationPlugin.swift
@@ -4,7 +4,8 @@ import UIKit
 public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
     var secured = false;
     var opacity: CGFloat = 0.2;
-    
+    var useLaunchImage: Bool = false;
+
     var backgroundTask: UIBackgroundTaskIdentifier!
     
     internal let registrar: FlutterPluginRegistrar
@@ -28,25 +29,52 @@ public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
         if let window = UIApplication.shared.windows.filter({ (w) -> Bool in
                    return w.isHidden == false
         }).first {
-            if let existingView = window.viewWithTag(99699) {
-                window.bringSubviewToFront(existingView)
-                return
-            } else {
-                let imageView = UIImageView.init(frame: window.bounds)
-                imageView.tag = 99699
-                imageView.backgroundColor = UIColor.black
-                imageView.tintColor = UIColor.white
-                imageView.clipsToBounds = true
-                imageView.contentMode = .center
-                imageView.image = UIImage(named: "LaunchImage")
-                imageView.isMultipleTouchEnabled = true
-                imageView.translatesAutoresizingMaskIntoConstraints = false
-                
-                window.addSubview(imageView)
-                window.bringSubviewToFront(imageView)
+            if (useLaunchImage) {
+                if let existingView = window.viewWithTag(99697) {
+                    window.bringSubviewToFront(existingView)
+                    return
+                } else {
+                    let imageView = UIImageView.init(frame: window.bounds)
+                    imageView.tag = 99697
+                    imageView.backgroundColor = UIColor.black
+                    imageView.tintColor = UIColor.white
+                    imageView.clipsToBounds = true
+                    imageView.contentMode = .center
+                    imageView.image = UIImage(named: "LaunchImage")
+                    imageView.isMultipleTouchEnabled = true
+                    imageView.translatesAutoresizingMaskIntoConstraints = false
 
-                window.snapshotView(afterScreenUpdates: true)
-                RunLoop.current.run(until: Date(timeIntervalSinceNow:0.5))
+                    window.addSubview(imageView)
+                    window.bringSubviewToFront(imageView)
+
+                    window.snapshotView(afterScreenUpdates: true)
+                    RunLoop.current.run(until: Date(timeIntervalSinceNow:0.5))
+                }
+            } else {
+                if let existingView = window.viewWithTag(99699), let existingBlurrView = window.viewWithTag(99698) {
+                    window.bringSubviewToFront(existingView)
+                    window.bringSubviewToFront(existingBlurrView)
+                    return
+                } else {
+                    let colorView = UIView(frame: window.bounds);
+                    colorView.tag = 99699
+                    colorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                    colorView.backgroundColor = UIColor(white: 1, alpha: opacity)
+                    window.addSubview(colorView)
+                    window.bringSubviewToFront(colorView)
+
+                    let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.extraLight)
+                    let blurEffectView = UIVisualEffectView(effect: blurEffect)
+                    blurEffectView.frame = window.bounds
+                    blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+                    blurEffectView.tag = 99698
+
+                    window.addSubview(blurEffectView)
+                    window.bringSubviewToFront(blurEffectView)
+                    window.snapshotView(afterScreenUpdates: true)
+                    RunLoop.current.run(until: Date(timeIntervalSinceNow:0.5))
+                }
             }
         }
     self.endBackgroundTask()
@@ -68,26 +96,47 @@ public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     if (call.method == "secure") {
         secured = true;
-        if let args = call.arguments as? Dictionary<String, Any>,
-        let opacity = args["opacity"] as? NSNumber {
-            self.opacity = opacity as! CGFloat
+        if let args = call.arguments as? Dictionary<String, Any> {
+            if let opacity = args["opacity"] as? NSNumber {
+                self.opacity = opacity as! CGFloat
+            }
+
+            if let useLaunchImage = args["useLaunchImage"] as? Bool {
+                 self.useLaunchImage = useLaunchImage
+             }
         }
     } else if (call.method == "open") {
         secured = false;
-    }  else if (call.method == "opacity") {
-            if let args = call.arguments as? Dictionary<String, Any>,
-                  let opacity = args["opacity"] as? NSNumber {
-               self.opacity = opacity as! CGFloat
-           }
+    } else if (call.method == "opacity") {
+        if let args = call.arguments as? Dictionary<String, Any>,
+              let opacity = args["opacity"] as? NSNumber {
+           self.opacity = opacity as! CGFloat
+       }
+    } else if (call.method == "useLaunchImage") {
+        if let args = call.arguments as? Dictionary<String, Any>,
+              let useLaunchImage = args["useLaunchImage"] as? Bool {
+           self.useLaunchImage = useLaunchImage
+       }
     } else if (call.method == "unlock") {
         if let window = UIApplication.shared.windows.filter({ (w) -> Bool in
                    return w.isHidden == false
-        }).first, let view = window.viewWithTag(99699) {
-            UIView.animate(withDuration: 0.5, animations: {
-                view.alpha = 0.0
-            }, completion: { finished in
-            view.removeFromSuperview()
-            })
+        }).first {
+            if let colorView = window.viewWithTag(99699), let blurrView = window.viewWithTag(99698) {
+                UIView.animate(withDuration: 0.5, animations: {
+                    colorView.alpha = 0.0
+                }, completion: { finished in
+                    colorView.removeFromSuperview()
+                    blurrView.removeFromSuperview()
+                })
+            }
+            
+            if let imageView = window.viewWithTag(99697) {
+                UIView.animate(withDuration: 0.3, animations: {
+                    imageView.alpha = 0.0
+                }, completion: { finished in
+                    imageView.removeFromSuperview()
+                })
+            }
         }
     }
   }

--- a/ios/Classes/SwiftSecureApplicationPlugin.swift
+++ b/ios/Classes/SwiftSecureApplicationPlugin.swift
@@ -28,27 +28,23 @@ public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
         if let window = UIApplication.shared.windows.filter({ (w) -> Bool in
                    return w.isHidden == false
         }).first {
-            if let existingView = window.viewWithTag(99699), let existingBlurrView = window.viewWithTag(99698) {
+            if let existingView = window.viewWithTag(99699) {
                 window.bringSubviewToFront(existingView)
-                window.bringSubviewToFront(existingBlurrView)
                 return
             } else {
-                let colorView = UIView(frame: window.bounds);
-                colorView.tag = 99699
-                colorView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                colorView.backgroundColor = UIColor(white: 1, alpha: opacity)
-                window.addSubview(colorView)
-                window.bringSubviewToFront(colorView)
+                let imageView = UIImageView.init(frame: window.bounds)
+                imageView.tag = 99699
+                imageView.backgroundColor = UIColor.black
+                imageView.tintColor = UIColor.white
+                imageView.clipsToBounds = true
+                imageView.contentMode = .center
+                imageView.image = UIImage(named: "LaunchImage")
+                imageView.isMultipleTouchEnabled = true
+                imageView.translatesAutoresizingMaskIntoConstraints = false
                 
-                let blurEffect = UIBlurEffect(style: UIBlurEffect.Style.extraLight)
-                let blurEffectView = UIVisualEffectView(effect: blurEffect)
-                blurEffectView.frame = window.bounds
-                blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                
-                blurEffectView.tag = 99698
+                window.addSubview(imageView)
+                window.bringSubviewToFront(imageView)
 
-                window.addSubview(blurEffectView)
-                window.bringSubviewToFront(blurEffectView)
                 window.snapshotView(afterScreenUpdates: true)
                 RunLoop.current.run(until: Date(timeIntervalSinceNow:0.5))
             }
@@ -86,14 +82,11 @@ public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
     } else if (call.method == "unlock") {
         if let window = UIApplication.shared.windows.filter({ (w) -> Bool in
                    return w.isHidden == false
-        }).first, let view = window.viewWithTag(99699), let blurrView = window.viewWithTag(99698) {
+        }).first, let view = window.viewWithTag(99699) {
             UIView.animate(withDuration: 0.5, animations: {
                 view.alpha = 0.0
-                blurrView.alpha = 0.0
             }, completion: { finished in
             view.removeFromSuperview()
-            blurrView.removeFromSuperview()
-                
             })
         }
     }

--- a/ios/Classes/SwiftSecureApplicationPlugin.swift
+++ b/ios/Classes/SwiftSecureApplicationPlugin.swift
@@ -129,7 +129,7 @@ public class SwiftSecureApplicationPlugin: NSObject, FlutterPlugin {
                     blurrView.removeFromSuperview()
                 })
             }
-            
+
             if let imageView = window.viewWithTag(99697) {
                 UIView.animate(withDuration: 0.3, animations: {
                     imageView.alpha = 0.0

--- a/lib/secure_application_native.dart
+++ b/lib/secure_application_native.dart
@@ -45,4 +45,10 @@ class SecureApplicationNative {
   static Future opacity(double opacity) {
     return _channel.invokeMethod('opacity', {"opacity": opacity});
   }
+
+  static Future useLaunchImageIOS(bool useLaunchImage) {
+    return _channel.invokeMethod('useLaunchImage', {
+      'useLaunchImage': useLaunchImage,
+    });
+  }
 }

--- a/lib/secure_gate.dart
+++ b/lib/secure_gate.dart
@@ -30,10 +30,10 @@ class SecureGate extends StatefulWidget {
   /// Whether to use the application's LaunchImage in the app switcher.
   ///
   /// For this to work, you MUST have a LaunchImage ImageSet in your iOS folder,
-  /// just like a newly generated flutter application. More info here:
-  /// https://docs.flutter.dev/development/ui/advanced/splash-screen#ios-launch-screen
+  /// just like a newly generated flutter application (at ios/Runner/Assets.xcassets/LaunchImage.imageset)
+  /// More info here: https://docs.flutter.dev/development/ui/advanced/splash-screen#ios-launch-screen
   ///
-  /// If this is true, [opacity] and [blurr] are ignored.
+  /// If this is true, [opacity] and [blurr] are ignored (iOS only).
   ///
   /// Only available on iOS. It is not possible on Android, as far as I'm aware
   final bool useLaunchImageIOS;

--- a/lib/secure_gate.dart
+++ b/lib/secure_gate.dart
@@ -27,12 +27,24 @@ class SecureGate extends StatefulWidget {
   /// default to 0.6
   final double opacity;
 
+  /// Whether to use the application's LaunchImage in the app switcher.
+  ///
+  /// For this to work, you MUST have a LaunchImage ImageSet in your iOS folder,
+  /// just like a newly generated flutter application. More info here:
+  /// https://docs.flutter.dev/development/ui/advanced/splash-screen#ios-launch-screen
+  ///
+  /// If this is true, [opacity] and [blurr] are ignored.
+  ///
+  /// Only available on iOS. It is not possible on Android, as far as I'm aware
+  final bool useLaunchImageIOS;
+
   const SecureGate({
     Key? key,
     required this.child,
     this.blurr = 20,
     this.opacity = 0.6,
     this.lockedBuilder,
+    this.useLaunchImageIOS = false,
   }) : super(key: key);
   @override
   _SecureGateState createState() => _SecureGateState();
@@ -50,6 +62,7 @@ class _SecureGateState extends State<SecureGate>
         AnimationController(vsync: this, duration: kThemeAnimationDuration * 2)
           ..addListener(_handleChange);
     SecureApplicationNative.opacity(widget.opacity);
+    SecureApplicationNative.useLaunchImageIOS(widget.useLaunchImageIOS);
 
     super.initState();
   }
@@ -69,6 +82,9 @@ class _SecureGateState extends State<SecureGate>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.opacity != widget.opacity) {
       SecureApplicationNative.opacity(widget.opacity);
+    }
+    if (oldWidget.useLaunchImageIOS != widget.useLaunchImageIOS) {
+      SecureApplicationNative.useLaunchImageIOS(widget.useLaunchImageIOS);
     }
   }
 


### PR DESCRIPTION
This adds a new parameter `useLaunchImageIOS` that will use the LaunchImage image set instead of a blank screen.