### PR TITLE
Fix build warnings on Flutter 3.0.0

### DIFF
--- a/lib/secure_application.dart
+++ b/lib/secure_application.dart
@@ -99,7 +99,7 @@ class _SecureApplicationState extends State<SecureApplication>
       }
     });
     super.initState();
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
     SecureApplicationNative.registerForEvents(
         secureApplicationController.lockIfSecured,
         secureApplicationController.unlock);
@@ -109,7 +109,7 @@ class _SecureApplicationState extends State<SecureApplication>
   void dispose() {
     _authStreamSubscription?.cancel();
     super.dispose();
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
   }
 
   @override
@@ -131,7 +131,7 @@ class _SecureApplicationState extends State<SecureApplication>
               if (authStatus != null)
                 secureApplicationController.sendAuthenticationEvent(authStatus);
 
-              WidgetsBinding.instance!.addPostFrameCallback((_) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
                 secureApplicationController.unpause();
               });
             }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/neckaros/secure_application
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This PR addresses #39 by fixing dart:unnecessary_non_null_assertion warning so that the package is compatible with Flutter version 3.0.0. Warning details: The '!' will have no effect because the receiver can't be null. Try removing the '!' operator.

[Warning about bindings in Flutter 3.0.0 release notes](https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#if-you-see-warnings-about-bindings)